### PR TITLE
Don't dispatch mutations that happen before a disconnect

### DIFF
--- a/done-mutation-observer.js
+++ b/done-mutation-observer.js
@@ -23,16 +23,19 @@ exports.addMutationObserver = function(window) {
 		this.callback = callback;
 		this.records = [];
 		this._enqueued = false;
+		this._connected = false;
 	}
 
 	MutationObserver.prototype.observe = function(root, options) {
 		this.root = root;
 		this.options = options;
 		window[mutationObserverSymbol].add(this);
+		this._connected = true;
 	};
 
 	MutationObserver.prototype.disconnect = function(){
 		window[mutationObserverSymbol].delete(this);
+		this._connected = false;
 	};
 
 	MutationObserver.prototype._enqueue = function(record) {
@@ -40,6 +43,10 @@ exports.addMutationObserver = function(window) {
 		if(!this._enqueued) {
 			this._enqueued = true;
 			asap(function(){
+				if(!this._connected) {
+					return;
+				}
+				
 				this._enqueued = false;
 				var records = this.records;
 				this.records = [];

--- a/test/test-childList.js
+++ b/test/test-childList.js
@@ -150,4 +150,40 @@ module.exports = function(implName, window) {
 		})
 		.run(assert);
 	});
+
+	QUnit.test("Does not receive mutations after disconnect()", function(assert){
+		assert.expect(2);
+		var done = assert.async();
+
+		function runTest(window) {
+			return new Promise(resolve => {
+				var observer = new window.MutationObserver(function() {
+					assert.ok(false, "Should not have called this");
+				});
+
+				observer.observe(window.document.body, {
+					childList: true
+				});
+
+				var div = window.document.createElement("div");
+				window.document.body.appendChild(div);
+
+				observer.disconnect();
+
+				setTimeout(function(){
+					assert.ok(true, "an assert after the mutation callback would have been called");
+					resolve();
+				});
+			});
+		}
+
+		Promise.all([
+			// The real window
+			runTest(self),
+
+			// Our fake dom window
+			runTest(window)
+		])
+		.then(done);
+	});
 };


### PR DESCRIPTION
If a mutation happens before a disconnect, it should not be dispatched.